### PR TITLE
Feature/BCSCP-4 Added initial BCSC realm + Upgrade to support Keycloak 18

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug, Development
+assignees: ''
+
+---
+
+Background:
+ 
+Steps to Reproduce:
+ 
+Actual Behavior:
+ 
+Expected Behaviour:
+ 
+Environment:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- 
+What are the main issue this PR is trying to solve?
+Give a high-level description of the changes.
+#Examples: Added a new Camunda workflow to support the Telework flow.
+-->
+
+## Changes
+<!-- 
+What are the main changes in the PR?
+List out the bigger changes made
+#Examples:
+- Added a search feature in web app
+- Renamed DB fields
+-->
+
+## Screenshots (if applicable)
+<!-- 
+Add screenshots highlighting the changes.
+-->
+
+## Notes
+<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

--- a/modules/base-realms/realm-azureidir/client-standard.tf
+++ b/modules/base-realms/realm-azureidir/client-standard.tf
@@ -2,6 +2,6 @@ module "standard_client" {
   source              = "../../standard-idp-client"
   realm_id            = module.realm.id
   client_id           = "${var.standard_realm_name}-realm"
-  valid_redirect_uris = ["${var.keycloak_url}/auth/realms/${var.standard_realm_name}/broker/${var.realm_name}/endpoint"]
+  valid_redirect_uris = ["${var.keycloak_url}/realms/${var.standard_realm_name}/broker/${var.realm_name}/endpoint"]
   public_attrs        = ["display_name", "idir_user_guid", "idir_username"]
 }

--- a/modules/base-realms/realm-azureidir/versions.tf
+++ b/modules/base-realms/realm-azureidir/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }

--- a/modules/base-realms/realm-bceidbasic/client-standard.tf
+++ b/modules/base-realms/realm-bceidbasic/client-standard.tf
@@ -2,6 +2,6 @@ module "standard_client" {
   source              = "../../standard-idp-client"
   realm_id            = module.realm.id
   client_id           = "${var.standard_realm_name}-realm"
-  valid_redirect_uris = ["${var.keycloak_url}/auth/realms/${var.standard_realm_name}/broker/${var.realm_name}/endpoint"]
+  valid_redirect_uris = ["${var.keycloak_url}/realms/${var.standard_realm_name}/broker/${var.realm_name}/endpoint"]
   public_attrs        = ["display_name", "bceid_user_guid", "bceid_username"]
 }

--- a/modules/base-realms/realm-bceidbasic/versions.tf
+++ b/modules/base-realms/realm-bceidbasic/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }

--- a/modules/base-realms/realm-bceidboth/client-standard.tf
+++ b/modules/base-realms/realm-bceidboth/client-standard.tf
@@ -2,6 +2,6 @@ module "standard_client" {
   source              = "../../standard-idp-client"
   realm_id            = module.realm.id
   client_id           = "${var.standard_realm_name}-realm"
-  valid_redirect_uris = ["${var.keycloak_url}/auth/realms/${var.standard_realm_name}/broker/${var.realm_name}/endpoint"]
+  valid_redirect_uris = ["${var.keycloak_url}/realms/${var.standard_realm_name}/broker/${var.realm_name}/endpoint"]
   public_attrs        = ["display_name", "bceid_user_guid", "bceid_business_guid", "bceid_business_name", "bceid_username"]
 }

--- a/modules/base-realms/realm-bceidboth/versions.tf
+++ b/modules/base-realms/realm-bceidboth/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }

--- a/modules/base-realms/realm-bceidbusiness/client-standard.tf
+++ b/modules/base-realms/realm-bceidbusiness/client-standard.tf
@@ -2,6 +2,6 @@ module "standard_client" {
   source              = "../../standard-idp-client"
   realm_id            = module.realm.id
   client_id           = "${var.standard_realm_name}-realm"
-  valid_redirect_uris = ["${var.keycloak_url}/auth/realms/${var.standard_realm_name}/broker/${var.realm_name}/endpoint"]
+  valid_redirect_uris = ["${var.keycloak_url}/realms/${var.standard_realm_name}/broker/${var.realm_name}/endpoint"]
   public_attrs        = ["display_name", "bceid_user_guid", "bceid_business_guid", "bceid_business_name", "bceid_username"]
 }

--- a/modules/base-realms/realm-bceidbusiness/versions.tf
+++ b/modules/base-realms/realm-bceidbusiness/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }

--- a/modules/base-realms/realm-bcsc/client-standard.tf
+++ b/modules/base-realms/realm-bcsc/client-standard.tf
@@ -1,0 +1,7 @@
+module "standard_client" {
+  source              = "../../standard-idp-client"
+  realm_id            = module.realm.id
+  client_id           = "${var.standard_realm_name}-realm"
+  valid_redirect_uris = ["${var.keycloak_url}/realms/${var.standard_realm_name}/broker/${var.realm_name}/endpoint"]
+  public_attrs        = ["display_name", "idir_user_guid", "idir_username"]
+}

--- a/modules/base-realms/realm-bcsc/idp-bcsc.tf
+++ b/modules/base-realms/realm-bcsc/idp-bcsc.tf
@@ -1,0 +1,88 @@
+module "bcsc_idp" {
+  source            = "../../oidc-idp"
+  realm_id          = module.realm.id
+  alias             = var.realm_name
+  authorization_url = "${var.bcsc_keycloak_url}/auth"
+  token_url         = "${var.bcsc_keycloak_url}/token"
+  user_info_url     = "${var.bcsc_keycloak_url}/userinfo"
+  client_id         = "<UPDATE_ME>"
+  client_secret     = "<UPDATE_ME>"
+}
+
+resource "keycloak_custom_identity_provider_mapper" "bcsc_firstname" {
+  realm                    = module.realm.id
+  name                     = "first_name"
+  identity_provider_alias  = module.bcsc_idp.alias
+  identity_provider_mapper = "oidc-user-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode         = "INHERIT"
+    "claim"          = "given_name"
+    "user.attribute" = "firstName"
+  }
+}
+
+resource "keycloak_custom_identity_provider_mapper" "bcsc_lastname" {
+  realm                    = module.realm.id
+  name                     = "last_name"
+  identity_provider_alias  = module.bcsc_idp.alias
+  identity_provider_mapper = "oidc-user-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode         = "INHERIT"
+    "claim"          = "family_name"
+    "user.attribute" = "lastName"
+  }
+}
+
+resource "keycloak_custom_identity_provider_mapper" "bcsc_displayname" {
+  realm                    = module.realm.id
+  name                     = "display_name"
+  identity_provider_alias  = module.bcsc_idp.alias
+  identity_provider_mapper = "oidc-user-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode         = "INHERIT"
+    "claim"          = "name"
+    "user.attribute" = "display_name"
+  }
+}
+
+resource "keycloak_custom_identity_provider_mapper" "bcsc_email" {
+  realm                    = module.realm.id
+  name                     = "email"
+  identity_provider_alias  = module.bcsc_idp.alias
+  identity_provider_mapper = "oidc-user-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode         = "INHERIT"
+    "claim"          = "email"
+    "user.attribute" = "email"
+  }
+}
+
+resource "keycloak_custom_identity_provider_mapper" "bcsc_idir_username" {
+  realm                    = module.realm.id
+  name                     = "idir_username"
+  identity_provider_alias  = module.bcsc_idp.alias
+  identity_provider_mapper = "oidc-user-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode         = "INHERIT"
+    "claim"          = "samaccountname"
+    "user.attribute" = "idir_username"
+  }
+}
+
+resource "keycloak_custom_identity_provider_mapper" "bcsc_idir_user_guid" {
+  realm                    = module.realm.id
+  name                     = "idir_user_guid"
+  identity_provider_alias  = module.bcsc_idp.alias
+  identity_provider_mapper = "oidc-user-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode         = "INHERIT"
+    "claim"          = "bcgovGUID"
+    "user.attribute" = "idir_user_guid"
+  }
+}

--- a/modules/base-realms/realm-bcsc/idp-bcsc.tf
+++ b/modules/base-realms/realm-bcsc/idp-bcsc.tf
@@ -2,9 +2,10 @@ module "bcsc_idp" {
   source            = "../../oidc-idp"
   realm_id          = module.realm.id
   alias             = var.realm_name
-  authorization_url = "${var.bcsc_keycloak_url}/auth"
-  token_url         = "${var.bcsc_keycloak_url}/token"
-  user_info_url     = "${var.bcsc_keycloak_url}/userinfo"
+  authorization_url = "${var.bcsc_keycloak_url}/login/oidc/authorize"
+  token_url         = "${var.bcsc_keycloak_url}/oauth2/token"
+  user_info_url     = "${var.bcsc_keycloak_url}/oauth2/userinfo"
+  jwks_url          = "${var.bcsc_keycloak_url}/oauth2/jwk"
   client_id         = "<UPDATE_ME>"
   client_secret     = "<UPDATE_ME>"
 }

--- a/modules/base-realms/realm-bcsc/idp-bcsc.tf
+++ b/modules/base-realms/realm-bcsc/idp-bcsc.tf
@@ -1,7 +1,7 @@
 module "bcsc_idp" {
   source            = "../../oidc-idp"
   realm_id          = module.realm.id
-  alias             = var.realm_name
+  alias             = var.bcsc_idp_alias
   authorization_url = "${var.bcsc_keycloak_url}/login/oidc/authorize"
   token_url         = "${var.bcsc_keycloak_url}/oauth2/token"
   user_info_url     = "${var.bcsc_keycloak_url}/oauth2/userinfo"

--- a/modules/base-realms/realm-bcsc/outputs.tf
+++ b/modules/base-realms/realm-bcsc/outputs.tf
@@ -1,0 +1,8 @@
+output "standard_client_id" {
+  value = module.standard_client.client_id
+}
+
+output "standard_client_secret" {
+  value     = module.standard_client.client_secret
+  sensitive = true
+}

--- a/modules/base-realms/realm-bcsc/realm.tf
+++ b/modules/base-realms/realm-bcsc/realm.tf
@@ -1,0 +1,26 @@
+module "realm" {
+  source     = "../../realm"
+  realm_name = var.realm_name
+}
+
+resource "keycloak_openid_client_scope" "idp_scope" {
+  realm_id               = module.realm.id
+  name                   = var.realm_name
+  description            = "${var.realm_name} idp client scope"
+  include_in_token_scope = false
+}
+
+data "keycloak_authentication_execution" "browser_identity_provider_redirector" {
+  realm_id          = module.realm.id
+  parent_flow_alias = "browser"
+  provider_id       = "identity-provider-redirector"
+}
+
+resource "keycloak_authentication_execution_config" "browser_identity_provider_redirector_config" {
+  realm_id     = module.realm.id
+  execution_id = data.keycloak_authentication_execution.browser_identity_provider_redirector.id
+  alias        = var.realm_name
+  config = {
+    defaultProvider = var.realm_name
+  }
+}

--- a/modules/base-realms/realm-bcsc/realm.tf
+++ b/modules/base-realms/realm-bcsc/realm.tf
@@ -5,8 +5,8 @@ module "realm" {
 
 resource "keycloak_openid_client_scope" "idp_scope" {
   realm_id               = module.realm.id
-  name                   = var.realm_name
-  description            = "${var.realm_name} idp client scope"
+  name                   = var.bcsc_idp_alias
+  description            = "${var.bcsc_idp_alias} idp client scope"
   include_in_token_scope = false
 }
 
@@ -19,7 +19,7 @@ data "keycloak_authentication_execution" "browser_identity_provider_redirector" 
 resource "keycloak_authentication_execution_config" "browser_identity_provider_redirector_config" {
   realm_id     = module.realm.id
   execution_id = data.keycloak_authentication_execution.browser_identity_provider_redirector.id
-  alias        = var.realm_name
+  alias        = var.bcsc_idp_alias
   config = {
     defaultProvider = var.realm_name
   }

--- a/modules/base-realms/realm-bcsc/realm.tf
+++ b/modules/base-realms/realm-bcsc/realm.tf
@@ -21,6 +21,6 @@ resource "keycloak_authentication_execution_config" "browser_identity_provider_r
   execution_id = data.keycloak_authentication_execution.browser_identity_provider_redirector.id
   alias        = var.bcsc_idp_alias
   config = {
-    defaultProvider = var.realm_name
+    defaultProvider = var.bcsc_idp_alias
   }
 }

--- a/modules/base-realms/realm-bcsc/variables.tf
+++ b/modules/base-realms/realm-bcsc/variables.tf
@@ -13,3 +13,7 @@ variable "realm_name" {
 variable "standard_realm_name" {
   default = "standard"
 }
+
+variable "bcsc_idp_alias" {
+  default = "bcsc"
+}

--- a/modules/base-realms/realm-bcsc/variables.tf
+++ b/modules/base-realms/realm-bcsc/variables.tf
@@ -1,0 +1,15 @@
+variable "keycloak_url" {
+  default = "http://localhost:8080"
+}
+
+variable "bcsc_keycloak_url" {
+  default = "https://login.microsoftonline.com/abcde/oauth2/v2.0"
+}
+
+variable "realm_name" {
+  default = "bcsc"
+}
+
+variable "standard_realm_name" {
+  default = "standard"
+}

--- a/modules/base-realms/realm-bcsc/versions.tf
+++ b/modules/base-realms/realm-bcsc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.1.4"
+
+  required_providers {
+    keycloak = {
+      source  = "mrparkers/keycloak"
+      version = "3.8.1"
+    }
+  }
+}

--- a/modules/base-realms/realm-idir/client-standard.tf
+++ b/modules/base-realms/realm-idir/client-standard.tf
@@ -2,6 +2,6 @@ module "standard_client" {
   source              = "../../standard-idp-client"
   realm_id            = module.realm.id
   client_id           = "${var.standard_realm_name}-realm"
-  valid_redirect_uris = ["${var.keycloak_url}/auth/realms/${var.standard_realm_name}/broker/${var.realm_name}/endpoint"]
+  valid_redirect_uris = ["${var.keycloak_url}/realms/${var.standard_realm_name}/broker/${var.realm_name}/endpoint"]
   public_attrs        = ["display_name", "idir_user_guid", "idir_username"]
 }

--- a/modules/base-realms/realm-idir/versions.tf
+++ b/modules/base-realms/realm-idir/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }

--- a/modules/base-realms/realm-standard/idp-azureidir.tf
+++ b/modules/base-realms/realm-standard/idp-azureidir.tf
@@ -2,10 +2,10 @@ module "azureidir_idp" {
   source            = "../../oidc-idp"
   realm_id          = module.realm.id
   alias             = var.azureidir_realm_name
-  authorization_url = "${var.keycloak_url}/auth/realms/${var.azureidir_realm_name}/protocol/openid-connect/auth"
-  token_url         = "${var.keycloak_url}/auth/realms/${var.azureidir_realm_name}/protocol/openid-connect/token"
-  user_info_url     = "${var.keycloak_url}/auth/realms/${var.azureidir_realm_name}/protocol/openid-connect/userinfo"
-  jwks_url          = "${var.keycloak_url}/auth/realms/${var.azureidir_realm_name}/protocol/openid-connect/certs"
+  authorization_url = "${var.keycloak_url}/realms/${var.azureidir_realm_name}/protocol/openid-connect/auth"
+  token_url         = "${var.keycloak_url}/realms/${var.azureidir_realm_name}/protocol/openid-connect/token"
+  user_info_url     = "${var.keycloak_url}/realms/${var.azureidir_realm_name}/protocol/openid-connect/userinfo"
+  jwks_url          = "${var.keycloak_url}/realms/${var.azureidir_realm_name}/protocol/openid-connect/certs"
   client_id         = var.azureidir_client_id
   client_secret     = var.azureidir_client_secret
 }

--- a/modules/base-realms/realm-standard/idp-bceidbasic.tf
+++ b/modules/base-realms/realm-standard/idp-bceidbasic.tf
@@ -2,10 +2,10 @@ module "bceidbasic_idp" {
   source            = "../../oidc-idp"
   realm_id          = module.realm.id
   alias             = var.bceidbasic_realm_name
-  authorization_url = "${var.keycloak_url}/auth/realms/${var.bceidbasic_realm_name}/protocol/openid-connect/auth"
-  token_url         = "${var.keycloak_url}/auth/realms/${var.bceidbasic_realm_name}/protocol/openid-connect/token"
-  user_info_url     = "${var.keycloak_url}/auth/realms/${var.bceidbasic_realm_name}/protocol/openid-connect/userinfo"
-  jwks_url          = "${var.keycloak_url}/auth/realms/${var.bceidbasic_realm_name}/protocol/openid-connect/certs"
+  authorization_url = "${var.keycloak_url}/realms/${var.bceidbasic_realm_name}/protocol/openid-connect/auth"
+  token_url         = "${var.keycloak_url}/realms/${var.bceidbasic_realm_name}/protocol/openid-connect/token"
+  user_info_url     = "${var.keycloak_url}/realms/${var.bceidbasic_realm_name}/protocol/openid-connect/userinfo"
+  jwks_url          = "${var.keycloak_url}/realms/${var.bceidbasic_realm_name}/protocol/openid-connect/certs"
   client_id         = var.bceidbasic_client_id
   client_secret     = var.bceidbasic_client_secret
 }

--- a/modules/base-realms/realm-standard/idp-bceidboth.tf
+++ b/modules/base-realms/realm-standard/idp-bceidboth.tf
@@ -2,10 +2,10 @@ module "bceidboth_idp" {
   source            = "../../oidc-idp"
   realm_id          = module.realm.id
   alias             = var.bceidboth_realm_name
-  authorization_url = "${var.keycloak_url}/auth/realms/${var.bceidboth_realm_name}/protocol/openid-connect/auth"
-  token_url         = "${var.keycloak_url}/auth/realms/${var.bceidboth_realm_name}/protocol/openid-connect/token"
-  user_info_url     = "${var.keycloak_url}/auth/realms/${var.bceidboth_realm_name}/protocol/openid-connect/userinfo"
-  jwks_url          = "${var.keycloak_url}/auth/realms/${var.bceidboth_realm_name}/protocol/openid-connect/certs"
+  authorization_url = "${var.keycloak_url}/realms/${var.bceidboth_realm_name}/protocol/openid-connect/auth"
+  token_url         = "${var.keycloak_url}/realms/${var.bceidboth_realm_name}/protocol/openid-connect/token"
+  user_info_url     = "${var.keycloak_url}/realms/${var.bceidboth_realm_name}/protocol/openid-connect/userinfo"
+  jwks_url          = "${var.keycloak_url}/realms/${var.bceidboth_realm_name}/protocol/openid-connect/certs"
   client_id         = var.bceidboth_client_id
   client_secret     = var.bceidboth_client_secret
 }

--- a/modules/base-realms/realm-standard/idp-bceidbusiness.tf
+++ b/modules/base-realms/realm-standard/idp-bceidbusiness.tf
@@ -2,10 +2,10 @@ module "bceidbusiness_idp" {
   source            = "../../oidc-idp"
   realm_id          = module.realm.id
   alias             = var.bceidbusiness_realm_name
-  authorization_url = "${var.keycloak_url}/auth/realms/${var.bceidbusiness_realm_name}/protocol/openid-connect/auth"
-  token_url         = "${var.keycloak_url}/auth/realms/${var.bceidbusiness_realm_name}/protocol/openid-connect/token"
-  user_info_url     = "${var.keycloak_url}/auth/realms/${var.bceidbusiness_realm_name}/protocol/openid-connect/userinfo"
-  jwks_url          = "${var.keycloak_url}/auth/realms/${var.bceidbusiness_realm_name}/protocol/openid-connect/certs"
+  authorization_url = "${var.keycloak_url}/realms/${var.bceidbusiness_realm_name}/protocol/openid-connect/auth"
+  token_url         = "${var.keycloak_url}/realms/${var.bceidbusiness_realm_name}/protocol/openid-connect/token"
+  user_info_url     = "${var.keycloak_url}/realms/${var.bceidbusiness_realm_name}/protocol/openid-connect/userinfo"
+  jwks_url          = "${var.keycloak_url}/realms/${var.bceidbusiness_realm_name}/protocol/openid-connect/certs"
   client_id         = var.bceidbusiness_client_id
   client_secret     = var.bceidbusiness_client_secret
 }

--- a/modules/base-realms/realm-standard/idp-bcsc.tf
+++ b/modules/base-realms/realm-standard/idp-bcsc.tf
@@ -1,0 +1,31 @@
+module "bcsc_idp" {
+  source            = "../../oidc-idp"
+  realm_id          = module.realm.id
+  alias             = var.bcsc_realm_name
+  authorization_url = "${var.keycloak_url}/realms/${var.bcsc_realm_name}/protocol/openid-connect/auth"
+  token_url         = "${var.keycloak_url}/realms/${var.bcsc_realm_name}/protocol/openid-connect/token"
+  user_info_url     = "${var.keycloak_url}/realms/${var.bcsc_realm_name}/protocol/openid-connect/userinfo"
+  jwks_url          = "${var.keycloak_url}/realms/${var.bcsc_realm_name}/protocol/openid-connect/certs"
+  client_id         = var.bcsc_client_id
+  client_secret     = var.bcsc_client_secret
+}
+
+module "bcsc_idp_mappers" {
+  source    = "../../idp-attribute-mappers"
+  realm_id  = module.realm.id
+  idp_alias = module.bcsc_idp.alias
+
+  attributes = local.bcsc_attributes
+}
+
+resource "keycloak_custom_identity_provider_mapper" "bcsc_username" {
+  realm                    = module.realm.id
+  name                     = "username"
+  identity_provider_alias  = module.bcsc_idp.alias
+  identity_provider_mapper = "oidc-username-idp-mapper"
+
+  extra_config = {
+    syncMode = "INHERIT"
+    template = "$${CLAIM.preferred_username}@$${ALIAS}"
+  }
+}

--- a/modules/base-realms/realm-standard/idp-idir.tf
+++ b/modules/base-realms/realm-standard/idp-idir.tf
@@ -2,10 +2,10 @@ module "idir_idp" {
   source            = "../../oidc-idp"
   realm_id          = module.realm.id
   alias             = var.idir_realm_name
-  authorization_url = "${var.keycloak_url}/auth/realms/${var.idir_realm_name}/protocol/openid-connect/auth"
-  token_url         = "${var.keycloak_url}/auth/realms/${var.idir_realm_name}/protocol/openid-connect/token"
-  user_info_url     = "${var.keycloak_url}/auth/realms/${var.idir_realm_name}/protocol/openid-connect/userinfo"
-  jwks_url          = "${var.keycloak_url}/auth/realms/${var.idir_realm_name}/protocol/openid-connect/certs"
+  authorization_url = "${var.keycloak_url}/realms/${var.idir_realm_name}/protocol/openid-connect/auth"
+  token_url         = "${var.keycloak_url}/realms/${var.idir_realm_name}/protocol/openid-connect/token"
+  user_info_url     = "${var.keycloak_url}/realms/${var.idir_realm_name}/protocol/openid-connect/userinfo"
+  jwks_url          = "${var.keycloak_url}/realms/${var.idir_realm_name}/protocol/openid-connect/certs"
   client_id         = var.idir_client_id
   client_secret     = var.idir_client_secret
 }

--- a/modules/base-realms/realm-standard/realm.tf
+++ b/modules/base-realms/realm-standard/realm.tf
@@ -4,6 +4,7 @@ locals {
   bceidbasic_attributes    = ["display_name", "bceid_user_guid", "bceid_username"]
   bceidbusiness_attributes = ["display_name", "bceid_user_guid", "bceid_business_guid", "bceid_business_name", "bceid_username"]
   bceidboth_attributes     = ["display_name", "bceid_user_guid", "bceid_business_guid", "bceid_business_name", "bceid_username"]
+  bcsc_attributes     = ["display_name", "bceid_user_guid", "bceid_business_guid", "bceid_business_name", "bceid_username"]
 }
 
 module "realm" {

--- a/modules/base-realms/realm-standard/scopes.tf
+++ b/modules/base-realms/realm-standard/scopes.tf
@@ -38,3 +38,10 @@ module "bceidboth_scope_mappers" {
   scope_name = var.bceidboth_realm_name
   attributes = local.bceidboth_attributes
 }
+
+module "bcsc_scope_mappers" {
+  source     = "../../scope-attribute-mappers"
+  realm_id   = module.realm.id
+  scope_name = var.bcsc_realm_name
+  attributes = local.bcsc_attributes
+}

--- a/modules/base-realms/realm-standard/variables.tf
+++ b/modules/base-realms/realm-standard/variables.tf
@@ -26,3 +26,6 @@ variable "bceidbusiness_client_secret" {}
 
 variable "bceidboth_client_id" {}
 variable "bceidboth_client_secret" {}
+
+variable "bcsc_client_id" {}
+variable "bcsc_client_secret" {}

--- a/modules/base-realms/realm-standard/variables.tf
+++ b/modules/base-realms/realm-standard/variables.tf
@@ -11,6 +11,7 @@ variable "azureidir_realm_name" {}
 variable "bceidbasic_realm_name" {}
 variable "bceidbusiness_realm_name" {}
 variable "bceidboth_realm_name" {}
+variable "bcsc_realm_name" {}
 
 variable "idir_client_id" {}
 variable "idir_client_secret" {}

--- a/modules/base-realms/realm-standard/versions.tf
+++ b/modules/base-realms/realm-standard/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }

--- a/modules/client-attribute-mappers/versions.tf
+++ b/modules/client-attribute-mappers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }

--- a/modules/idp-attribute-mappers/versions.tf
+++ b/modules/idp-attribute-mappers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }

--- a/modules/idp-stopper-auth-flow/versions.tf
+++ b/modules/idp-stopper-auth-flow/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }

--- a/modules/master-idp-link/main.tf
+++ b/modules/master-idp-link/main.tf
@@ -6,7 +6,7 @@ module "idp_client" {
   source              = "../standard-idp-client"
   realm_id            = var.idp_realm_id
   client_id           = "master-realm"
-  valid_redirect_uris = ["${var.keycloak_url}/auth/realms/master/broker/${var.idp_realm_name}/endpoint"]
+  valid_redirect_uris = ["${var.keycloak_url}/realms/master/broker/${var.idp_realm_name}/endpoint"]
   public_attrs        = var.idp_public_attrs
 }
 
@@ -14,10 +14,10 @@ module "master_idp" {
   source            = "../oidc-idp"
   realm_id          = data.keycloak_realm.master.id
   alias             = var.idp_realm_name
-  authorization_url = "${var.keycloak_url}/auth/realms/${var.idp_realm_name}/protocol/openid-connect/auth"
-  token_url         = "${var.keycloak_url}/auth/realms/${var.idp_realm_name}/protocol/openid-connect/token"
-  user_info_url     = "${var.keycloak_url}/auth/realms/${var.idp_realm_name}/protocol/openid-connect/userinfo"
-  jwks_url          = "${var.keycloak_url}/auth/realms/${var.idp_realm_name}/protocol/openid-connect/certs"
+  authorization_url = "${var.keycloak_url}/realms/${var.idp_realm_name}/protocol/openid-connect/auth"
+  token_url         = "${var.keycloak_url}/realms/${var.idp_realm_name}/protocol/openid-connect/token"
+  user_info_url     = "${var.keycloak_url}/realms/${var.idp_realm_name}/protocol/openid-connect/userinfo"
+  jwks_url          = "${var.keycloak_url}/realms/${var.idp_realm_name}/protocol/openid-connect/certs"
   client_id         = module.idp_client.client_id
   client_secret     = module.idp_client.client_secret
 }

--- a/modules/master-idp-link/versions.tf
+++ b/modules/master-idp-link/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }

--- a/modules/master-viewer-role/versions.tf
+++ b/modules/master-viewer-role/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }

--- a/modules/oidc-idp/versions.tf
+++ b/modules/oidc-idp/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }

--- a/modules/realm/versions.tf
+++ b/modules/realm/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }

--- a/modules/saml-idp/versions.tf
+++ b/modules/saml-idp/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }

--- a/modules/scope-attribute-mappers/versions.tf
+++ b/modules/scope-attribute-mappers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }

--- a/modules/scope-common-mappers/versions.tf
+++ b/modules/scope-common-mappers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }

--- a/modules/standard-client/versions.tf
+++ b/modules/standard-client/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }

--- a/modules/standard-idp-client/versions.tf
+++ b/modules/standard-idp-client/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = "3.7.0"
+      version = "3.8.1"
     }
   }
 }


### PR DESCRIPTION
## Summary
Added a KeyCloak module to create a basic BCSC realm + added initial configuration for a BCSC IDP. This is based on the existing `azureidir` IDP. 

TODO (separate tickets):
- Update IDP config once we have more info on what this might look like
- Update variable mappers (currently references IDIR)
<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
- Added BCSC realm + IDP
- auth/realms -> /realms (new url structure in Keycloak 18)
- Upgraded to latest Keycloak TF provider
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->
