### PR TITLE
BCSCP-11 Added user attribute mapping for the BCSC IDP

### DIFF
--- a/modules/base-realms/realm-bcsc/client-standard.tf
+++ b/modules/base-realms/realm-bcsc/client-standard.tf
@@ -3,5 +3,22 @@ module "standard_client" {
   realm_id            = module.realm.id
   client_id           = "${var.standard_realm_name}-realm"
   valid_redirect_uris = ["${var.keycloak_url}/realms/${var.standard_realm_name}/broker/${var.realm_name}/endpoint"]
-  public_attrs        = ["display_name", "idir_user_guid", "idir_username"]
+  public_attrs        = [
+    "address",
+    "address",
+    "age",
+    "age19OrOver",
+    "birthDate",
+    "country",
+    "display_name",
+    "email",
+    "firstName",
+    "gender",
+    "gender",
+    "lastName",
+    "locality",
+    "postalCode",
+    "region",
+    "streetAddress"
+  ]
 }

--- a/modules/base-realms/realm-bcsc/client-standard.tf
+++ b/modules/base-realms/realm-bcsc/client-standard.tf
@@ -5,7 +5,6 @@ module "standard_client" {
   valid_redirect_uris = ["${var.keycloak_url}/realms/${var.standard_realm_name}/broker/${var.realm_name}/endpoint"]
   public_attrs        = [
     "address",
-    "address",
     "age",
     "age19OrOver",
     "birthDate",
@@ -13,7 +12,6 @@ module "standard_client" {
     "display_name",
     "email",
     "firstName",
-    "gender",
     "gender",
     "lastName",
     "locality",

--- a/modules/base-realms/realm-bcsc/idp-bcsc.tf
+++ b/modules/base-realms/realm-bcsc/idp-bcsc.tf
@@ -112,19 +112,6 @@ resource "keycloak_custom_identity_provider_mapper" "bcsc_sex" {
   }
 }
 
-resource "keycloak_custom_identity_provider_mapper" "bcsc_sex" {
-  realm                    = module.realm.id
-  name                     = "sex"
-  identity_provider_alias  = module.bcsc_idp.alias
-  identity_provider_mapper = "oidc-user-attribute-idp-mapper"
-
-  extra_config = {
-    syncMode         = "INHERIT"
-    "claim"          = "gender"
-    "user.attribute" = "gender"
-  }
-}
-
 resource "keycloak_custom_identity_provider_mapper" "bcsc_locality" {
   realm                    = module.realm.id
   name                     = "locality"

--- a/modules/base-realms/realm-bcsc/idp-bcsc.tf
+++ b/modules/base-realms/realm-bcsc/idp-bcsc.tf
@@ -6,20 +6,32 @@ module "bcsc_idp" {
   token_url         = "${var.bcsc_keycloak_url}/oauth2/token"
   user_info_url     = "${var.bcsc_keycloak_url}/oauth2/userinfo"
   jwks_url          = "${var.bcsc_keycloak_url}/oauth2/jwk"
-  client_id         = "<UPDATE_ME>"
-  client_secret     = "<UPDATE_ME>"
+  client_id         = "${var.bcsc_client_id}"
+  client_secret     = "${var.bcsc_client_secret}"
 }
 
-resource "keycloak_custom_identity_provider_mapper" "bcsc_firstname" {
+resource "keycloak_custom_identity_provider_mapper" "bcsc_displayname" {
   realm                    = module.realm.id
-  name                     = "first_name"
+  name                     = "display_name"
   identity_provider_alias  = module.bcsc_idp.alias
   identity_provider_mapper = "oidc-user-attribute-idp-mapper"
 
   extra_config = {
     syncMode         = "INHERIT"
-    "claim"          = "given_name"
-    "user.attribute" = "firstName"
+    "claim"          = "display_name"
+    "user.attribute" = "display_name"
+  }
+}
+resource "keycloak_custom_identity_provider_mapper" "bcsc_email" {
+  realm                    = module.realm.id
+  name                     = "email"
+  identity_provider_alias  = module.bcsc_idp.alias
+  identity_provider_mapper = "oidc-user-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode         = "INHERIT"
+    "claim"          = "email"
+    "user.attribute" = "email"
   }
 }
 
@@ -36,54 +48,157 @@ resource "keycloak_custom_identity_provider_mapper" "bcsc_lastname" {
   }
 }
 
-resource "keycloak_custom_identity_provider_mapper" "bcsc_displayname" {
+resource "keycloak_custom_identity_provider_mapper" "bcsc_firstname" {
   realm                    = module.realm.id
-  name                     = "display_name"
+  name                     = "first_name"
   identity_provider_alias  = module.bcsc_idp.alias
   identity_provider_mapper = "oidc-user-attribute-idp-mapper"
 
   extra_config = {
     syncMode         = "INHERIT"
-    "claim"          = "name"
-    "user.attribute" = "display_name"
+    "claim"          = "given_name"
+    "user.attribute" = "firstName"
+  }
+}
+resource "keycloak_custom_identity_provider_mapper" "bcsc_birthdate" {
+  realm                    = module.realm.id
+  name                     = "birth_date"
+  identity_provider_alias  = module.bcsc_idp.alias
+  identity_provider_mapper = "oidc-user-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode         = "INHERIT"
+    "claim"          = "birthdate"
+    "user.attribute" = "birthDate"
   }
 }
 
-resource "keycloak_custom_identity_provider_mapper" "bcsc_email" {
+resource "keycloak_custom_identity_provider_mapper" "bcsc_age" {
   realm                    = module.realm.id
-  name                     = "email"
+  name                     = "age"
   identity_provider_alias  = module.bcsc_idp.alias
   identity_provider_mapper = "oidc-user-attribute-idp-mapper"
 
   extra_config = {
     syncMode         = "INHERIT"
-    "claim"          = "email"
-    "user.attribute" = "email"
+    "claim"          = "age"
+    "user.attribute" = "age"
   }
 }
 
-resource "keycloak_custom_identity_provider_mapper" "bcsc_idir_username" {
+resource "keycloak_custom_identity_provider_mapper" "bcsc_age19orover" {
   realm                    = module.realm.id
-  name                     = "idir_username"
+  name                     = "age_19_or_over"
   identity_provider_alias  = module.bcsc_idp.alias
   identity_provider_mapper = "oidc-user-attribute-idp-mapper"
 
   extra_config = {
     syncMode         = "INHERIT"
-    "claim"          = "samaccountname"
-    "user.attribute" = "idir_username"
+    "claim"          = "age_19_or_over"
+    "user.attribute" = "age19OrOver"
   }
 }
 
-resource "keycloak_custom_identity_provider_mapper" "bcsc_idir_user_guid" {
+resource "keycloak_custom_identity_provider_mapper" "bcsc_sex" {
   realm                    = module.realm.id
-  name                     = "idir_user_guid"
+  name                     = "sex"
   identity_provider_alias  = module.bcsc_idp.alias
   identity_provider_mapper = "oidc-user-attribute-idp-mapper"
 
   extra_config = {
     syncMode         = "INHERIT"
-    "claim"          = "bcgovGUID"
-    "user.attribute" = "idir_user_guid"
+    "claim"          = "gender"
+    "user.attribute" = "gender"
+  }
+}
+
+resource "keycloak_custom_identity_provider_mapper" "bcsc_sex" {
+  realm                    = module.realm.id
+  name                     = "sex"
+  identity_provider_alias  = module.bcsc_idp.alias
+  identity_provider_mapper = "oidc-user-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode         = "INHERIT"
+    "claim"          = "gender"
+    "user.attribute" = "gender"
+  }
+}
+
+resource "keycloak_custom_identity_provider_mapper" "bcsc_locality" {
+  realm                    = module.realm.id
+  name                     = "locality"
+  identity_provider_alias  = module.bcsc_idp.alias
+  identity_provider_mapper = "oidc-user-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode         = "INHERIT"
+    "claim"          = "locality"
+    "user.attribute" = "locality"
+  }
+}
+
+resource "keycloak_custom_identity_provider_mapper" "bcsc_state_or_province" {
+  realm                    = module.realm.id
+  name                     = "state_or_province"
+  identity_provider_alias  = module.bcsc_idp.alias
+  identity_provider_mapper = "oidc-user-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode         = "INHERIT"
+    "claim"          = "region"
+    "user.attribute" = "region"
+  }
+}
+
+resource "keycloak_custom_identity_provider_mapper" "bcsc_postal_code" {
+  realm                    = module.realm.id
+  name                     = "postal_code"
+  identity_provider_alias  = module.bcsc_idp.alias
+  identity_provider_mapper = "oidc-user-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode         = "INHERIT"
+    "claim"          = "postal_code"
+    "user.attribute" = "postalCode"
+  }
+}
+
+resource "keycloak_custom_identity_provider_mapper" "bcsc_country" {
+  realm                    = module.realm.id
+  name                     = "country"
+  identity_provider_alias  = module.bcsc_idp.alias
+  identity_provider_mapper = "oidc-user-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode         = "INHERIT"
+    "claim"          = "country"
+    "user.attribute" = "country"
+  }
+}
+
+resource "keycloak_custom_identity_provider_mapper" "bcsc_address" {
+  realm                    = module.realm.id
+  name                     = "address"
+  identity_provider_alias  = module.bcsc_idp.alias
+  identity_provider_mapper = "oidc-user-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode         = "INHERIT"
+    "claim"          = "address"
+    "user.attribute" = "address"
+  }
+}
+
+resource "keycloak_custom_identity_provider_mapper" "bcsc_street_address" {
+  realm                    = module.realm.id
+  name                     = "street_address"
+  identity_provider_alias  = module.bcsc_idp.alias
+  identity_provider_mapper = "oidc-user-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode         = "INHERIT"
+    "claim"          = "street_address"
+    "user.attribute" = "streetAddress"
   }
 }

--- a/modules/base-realms/realm-bcsc/variables.tf
+++ b/modules/base-realms/realm-bcsc/variables.tf
@@ -17,3 +17,13 @@ variable "standard_realm_name" {
 variable "bcsc_idp_alias" {
   default = "bcsc"
 }
+
+variable "bcsc_client_id" {
+  sensitive = true
+  type = string
+}
+
+variable "bcsc_client_secret" {
+  sensitive = true
+  type = string
+}

--- a/modules/base-realms/realm-standard/realm.tf
+++ b/modules/base-realms/realm-standard/realm.tf
@@ -4,8 +4,25 @@ locals {
   bceidbasic_attributes    = ["display_name", "bceid_user_guid", "bceid_username"]
   bceidbusiness_attributes = ["display_name", "bceid_user_guid", "bceid_business_guid", "bceid_business_name", "bceid_username"]
   bceidboth_attributes     = ["display_name", "bceid_user_guid", "bceid_business_guid", "bceid_business_name", "bceid_username"]
-  bcsc_attributes     = ["display_name", "bceid_user_guid", "bceid_business_guid", "bceid_business_name", "bceid_username"]
+  bcsc_attributes     = [
+    "address",
+    "age",
+    "age19OrOver",
+    "birthDate",
+    "country",
+    "display_name",
+    "email",
+    "firstName",
+    "gender",
+    "lastName",
+    "locality",
+    "postalCode",
+    "region",
+    "streetAddress"
+  ]
 }
+
+
 
 module "realm" {
   source      = "../../realm"


### PR DESCRIPTION
## Summary
Added `custom_identity_provider_mapper`s for attributes returned from BCSC according to this spreadsheet: [SSAG Attribute Mapping](https://docs.google.com/spreadsheets/d/1oLe-9Lcqf6gYB6be2oMzNCpyuHlyofplBl-2ZOSH1bo/edit?usp=sharing).



<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
- Added `keycloak_custom_identity_provider_mapper` for BCSC attributes
- Allow passing bcsc client id / secret to BCSC module 
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
There's a couple of leftover attributes to deal with (sub/username) that requires a bit more work, so a separate PR will be created for those.

<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->