### PR TITLE
BCSCP-11 Fixed bcsc duplicate scope

### DIFF
--- a/modules/standard-client/main.tf
+++ b/modules/standard-client/main.tf
@@ -60,8 +60,8 @@ resource "keycloak_openid_client_default_scopes" "idp_scopes" {
 
   default_scopes = distinct(
     concat(["profile", "email"],
-    var.idps,
-    contains(var.idps, "bcsc")? [var.bcsc_idp_alias] : [])
+    contains(var.idps, "bcsc")? [var.bcsc_idp_alias] : []),
+    setsubtract(var.idps, ["bcsc"])
   )
 }
 


### PR DESCRIPTION
## Summary
Remove `bcsc` from list of default scopes, so it doesn't conflict with the `bcsc` scope from app 1 IDP. This should hopefully fix the error that's now happening in dev

<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->
![image](https://user-images.githubusercontent.com/66635118/172702493-d8b0f9fe-2b3d-4041-8251-d9338941d5ef.png)

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->