### PR TITLE
BCSCP-11 Fix setsubtract function call + added bcsc default scopes

### DIFF
--- a/modules/bcsc-idp/main.tf
+++ b/modules/bcsc-idp/main.tf
@@ -8,6 +8,7 @@ module "bcsc_idp" {
   jwks_url          = "${var.bcsc_keycloak_url}/oauth2/jwk"
   client_id         = "${var.client_id}"
   client_secret     = "${var.client_secret}"
+  default_scopes    = "openid profile email address"
 }
 
 resource "keycloak_custom_identity_provider_mapper" "bcsc_displayname" {

--- a/modules/bcsc-idp/standard-idp-client.tf
+++ b/modules/bcsc-idp/standard-idp-client.tf
@@ -27,7 +27,6 @@ module "bcsc_idp_standard" {
   jwks_url          = "${var.keycloak_url}/realms/${var.realm_name}/protocol/openid-connect/certs"
   client_id         = module.standard_client.client_id
   client_secret     = module.standard_client.client_secret
-  default_scopes    = "openid profile email address"
 }
 
 module "bcsc_idp_mappers" {

--- a/modules/bcsc-idp/standard-idp-client.tf
+++ b/modules/bcsc-idp/standard-idp-client.tf
@@ -21,7 +21,7 @@ module "bcsc_idp_standard" {
   source            = "../oidc-idp"
   realm_id          = var.standard_realm_id
   alias             = var.idp_alias
-  authorization_url = "${var.keycloak_url}/realms/${var.realm_name}/protocol/openid-connect/auth"
+  authorization_url = "${var.keycloak_url}/realms/${var.realm_name}/protocol/openid-connect/auth?kc_idp_hint=${var.idp_alias}"
   token_url         = "${var.keycloak_url}/realms/${var.realm_name}/protocol/openid-connect/token"
   user_info_url     = "${var.keycloak_url}/realms/${var.realm_name}/protocol/openid-connect/userinfo"
   jwks_url          = "${var.keycloak_url}/realms/${var.realm_name}/protocol/openid-connect/certs"

--- a/modules/bcsc-idp/standard-idp-client.tf
+++ b/modules/bcsc-idp/standard-idp-client.tf
@@ -27,6 +27,7 @@ module "bcsc_idp_standard" {
   jwks_url          = "${var.keycloak_url}/realms/${var.realm_name}/protocol/openid-connect/certs"
   client_id         = module.standard_client.client_id
   client_secret     = module.standard_client.client_secret
+  default_scopes    = ["openid", "profile", "email", "address"]
 }
 
 module "bcsc_idp_mappers" {

--- a/modules/bcsc-idp/standard-idp-client.tf
+++ b/modules/bcsc-idp/standard-idp-client.tf
@@ -27,7 +27,7 @@ module "bcsc_idp_standard" {
   jwks_url          = "${var.keycloak_url}/realms/${var.realm_name}/protocol/openid-connect/certs"
   client_id         = module.standard_client.client_id
   client_secret     = module.standard_client.client_secret
-  default_scopes    = ["openid", "profile", "email", "address"]
+  default_scopes    = "openid profile email address"
 }
 
 module "bcsc_idp_mappers" {

--- a/modules/oidc-idp/main.tf
+++ b/modules/oidc-idp/main.tf
@@ -31,6 +31,8 @@ resource "keycloak_oidc_identity_provider" "this" {
   disable_user_info                       = var.disable_user_info
   accepts_prompt_none_forward_from_client = var.accepts_prompt_none_forward_from_client
 
+  default_scopes = var.default_scopes
+
   extra_config = {
     "clientAuthMethod" = var.client_auth_method
   }

--- a/modules/standard-client/main.tf
+++ b/modules/standard-client/main.tf
@@ -62,7 +62,10 @@ resource "keycloak_openid_client_default_scopes" "idp_scopes" {
     concat(
       ["profile", "email"],
       contains(var.idps, "bcsc")? [var.bcsc_idp_alias] : [],
-      setsubtract(var.idps, ["bcsc"])
+      [
+        for idp in var.idps:
+        idp if idp != "bcsc"
+      ]
     )
   )
 }

--- a/modules/standard-client/main.tf
+++ b/modules/standard-client/main.tf
@@ -59,9 +59,11 @@ resource "keycloak_openid_client_default_scopes" "idp_scopes" {
   client_id = keycloak_openid_client.this.id
 
   default_scopes = distinct(
-    concat(["profile", "email"],
-    contains(var.idps, "bcsc")? [var.bcsc_idp_alias] : []),
-    setsubtract(var.idps, ["bcsc"])
+    concat(
+      ["profile", "email"],
+      contains(var.idps, "bcsc")? [var.bcsc_idp_alias] : [],
+      setsubtract(var.idps, ["bcsc"])
+    )
   )
 }
 


### PR DESCRIPTION
## Summary
- Switched from setsubtract to manual exclusion of `bcsc` idp to fix error. Should hopefully fix TF errors that popped up.
- Added "openid", "profile", "email", "address" scopes to bcsc idp - should fix missing attributes
- Added `kc_idp_hint` to bcsc idps in standard realm, to make sure you're redirected to the correct IDP for the current app

<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->